### PR TITLE
Update help message to clarify exit command wording

### DIFF
--- a/test.py
+++ b/test.py
@@ -13,7 +13,7 @@ def show_help():
 Available Commands:
   help           - Show this help message
   clear          - Clear the screen
-  exit           - Close/Exit the shell
+  exit           - Exit the shell
   echo [text]    - Print the given text
   os             - Show OS information
   cwd            - Show current working directory


### PR DESCRIPTION
## Summary by Sourcery

Documentation:
- Clarify exit command description to “Exit the shell”